### PR TITLE
Add a demo app endpoint and api key

### DIFF
--- a/src/app/skygear.service.ts
+++ b/src/app/skygear.service.ts
@@ -9,8 +9,8 @@ export class SkygearService {
       return Promise.resolve(skygear);
     }
     let promise = skygear.config({
-      'endPoint': 'https://<your-app-name>.skygeario.com/', // trailing slash is required
-      'apiKey': '<your-api-key>',
+      'endPoint': 'https://skygearangular.skygeario.com/', // trailing slash is required
+      'apiKey': '8397832bcb9d4c57b5833b532ef1a77c',
     });
     promise.then(()=> this.isConfigurated = true);
     return promise;


### PR DESCRIPTION
We will want to use npm install and start without exception. Adding a demo
endpoint also provide us some insight on weather people will clone and run the
code.